### PR TITLE
governance files: CODEOWNERS, CONTRIBUTING.md, and GOVERNANCE.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,20 @@
+# This CODEOWNERS file denotes the project leads
+# and encodes their responsibilities for code review.
+
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# The format is described: https://github.blog/2017-07-06-introducing-code-owners/
+
+
+# These owners will be the default owners for everything in the repo.
+*       @talltree @wenjing
+
+-----------------------------------------------
+# BELOW THIS LINE ARE TEMPLATES, UNUSED
+# -----------------------------------------------
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+# *.js    @octocat @github/js
+
+# You can also use email addresses if you prefer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,16 +49,26 @@ use to get going and to contribute to the repository *without ever touching the
 command line*.
 
 1. [Fork the TechArch repo into your
-   account](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
+   account](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+   
+   <div align="center"><img width=400 src=https://user-images.githubusercontent.com/8604639/196454640-13428816-918b-43d1-af7b-24c54959f756.png></div>
+   
+   <div align="center"><img width=400 src=https://user-images.githubusercontent.com/8604639/196456303-be5ccc86-9f7b-4159-9387-2d4260333516.png></div>
+
 2. Find the file you want to edit. [Click the pen tool on the top right of the
-   file to edit it.](https://www.youtube.com/watch?v=uE2DxUfZjtE) If you want to
-   add a file, click "Add File". Generally, when you save it is better to click
-   "create new branch".
+   file to edit it]([https://www.youtube.com/watch?v=uE2DxUfZjtE](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files)). If you want to add a file, click "Add File". Click "create new branch". [Learn More](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files)
+   
+   <div align="center"><img width=400 src=https://user-images.githubusercontent.com/8604639/196453797-8cf73fee-e032-44d0-a32b-fcdf7dccf3fc.png></div>
+   <div align="center"><img width=400 src=https://user-images.githubusercontent.com/8604639/196456484-ac4160a4-657d-4ef3-bca5-21ad0fa9d8e8.png></div>
+
 3. Make your changes. When you are ready, click [Pull
    Request](https://youtu.be/rgbCcBNZcdQ?t=205) on the bar above the file. Then
    create `New Pull Request` and choose to set the request to merge to the
    `TechArch:main` branch. Put any information you want to describe your changes
-   on the description, and you're done!
+   on the description, and you're done! [Learn More](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
+   
+   <div align="center"><img width=400 src=https://user-images.githubusercontent.com/8604639/196454843-23080862-1f8a-4514-a3e0-59bfb9350adf.png></div>
+   <div align="center"><img width=400 src=https://user-images.githubusercontent.com/8604639/196454824-a20039f9-ab87-4806-b321-891eea222438.png></div>
    
 ### Advanced Change Flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,14 +130,19 @@ issue, so that we may accurately classify the work to do on it.
   the PR in the issue
 
 ### Editing Git process
-1) Create a
+1. Create a
  [clone](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository) of
  the repo or
  [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
- the repo 2) Make changes to the document on your own repo 3) Ensure commit
- history sync by rebasing own repo with 'git pull rebase' 4) Create a pull
- request against the ToIP repo main branch 5) Refer to the PR in the relevant
- issue(s). 6) Contributor sets the issue to label "Needs review" to signal
+ the repo 
+ 2. Make changes to the document on your own repo 
+ 3. Ensure commit
+ history sync by rebasing own repo with 'git pull rebase' 
+ 4. Create a pull
+ request against the ToIP repo main branch 
+ 5. Refer to the PR in the relevant
+ issue(s). 
+ 6. Contributor sets the issue to label "Needs review" to signal
  editors to review the changes
 
 You may also put your PR in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,12 @@
 There are many ways to be a contributor, and we're here to help you on your way!
 You may:
 
-* Join the discussion and share ideas in our [Slack channel](trustoverip.slack.com) and regular [TSWG](https://wiki.trustoverip.org/display/HOME/Technology+Stack+Working+Group?src=contextnavpagetreemode) and [TATF](https://wiki.trustoverip.org/display/HOME/Technology+Architecture+Task+Force) meetings.
+* Join the discussion and share ideas in our [Slack
+  channel](trustoverip.slack.com) and regular
+  [TSWG](https://wiki.trustoverip.org/display/HOME/Technology+Stack+Working+Group?src=contextnavpagetreemode)
+  and
+  [TATF](https://wiki.trustoverip.org/display/HOME/Technology+Architecture+Task+Force)
+  meetings.
 * Raise an [issue](https://github.com/trustoverip/TechArch/issues) or feature
   request in our issue tracker
 * Help another contributor with one of their questions, or a documentation
@@ -18,36 +23,128 @@ This guide is for you.
 
 ## Table Of Contents
 
-* [Setup](#setup)
-* [Branching And Tagging](#branching-and-tagging)
+* [Contributing](#contributing)
+  * [Basic Flow](#basic-change-flow)
+  * [Advanced Flow](#advanced-change-flow)
+  * [Commits](#commits)
+  * [Branching](#branching)
+  * [Tagging](#tagging)
+  * [Pull Requests](#pull-requests)
+  * [Review](#review)
 * [Issues](#issues)
 * [Labels](#labels)
   * [Priority Labels](#priority-labels)
   * [Type Labels](#type-labels)
   * [Status Labels](#status-labels)
-* [Changes to Document](#changes-to-document)
-* [Editing Git Process](#editing-git-process)
-* [Review and Merge Process](#review-and-merge-process)
 
-## Contribution
+## Contributing
 
-### Branching and Tagging:
+This section is designed to help you make an edit if you aren't familiar with
+using Github and want to make a change to the TechArch repository.
 
+### Basic Change Flow
+
+If you're not familiar with Github and Git, here's a few simple steps you can
+use to get going and to contribute to the repository *without ever touching the
+command line*.
+
+1. [Fork the TechArch repo into your
+   account](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
+2. Find the file you want to edit. [Click the pen tool on the top right of the
+   file to edit it.](https://www.youtube.com/watch?v=uE2DxUfZjtE) If you want to
+   add a file, click "Add File". Generally, when you save it is better to click
+   "create new branch".
+3. Make your changes. When you are ready, click [Pull
+   Request](https://youtu.be/rgbCcBNZcdQ?t=205) on the bar above the file. Then
+   create `New Pull Request` and choose to set the request to merge to the
+   `TechArch:main` branch. Put any information you want to describe your changes
+   on the description, and you're done!
+   
+### Advanced Change Flow
+
+As a more advanced user, there are few ways you can manage your Github
+repository:
+
+1. [You can use the github web
+   editor](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor)
+2. [You can use github desktop](https://desktop.github.com/)
+3. [You can use the
+   cli](https://git-scm.com/book/en/v2/Getting-Started-The-Command-Line)
+4. Something else! Git is extremely powerful if you want to spend the time
+   researching.
+
+### Commits
+
+- [You must sign your
+  commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+- Please try to keep your commit history clean. We do not enforce this but it is
+  encouraged.
+
+### Branching:
+
+- Nobody will work directly on the `main` branch. All changes must occur over a
+  PR and off the main branch.
+- We encourage, but do not enforce branching naming using the following schema:
+  `<type>/<description>` ex. `edit/fix-fig4-label`.
 - The main-branch should always have the latest approved changes
 - Custom "feature" branches may be used for special purposes, e.g. for groups to
   work on a larger section of text
+- Branching will occur on forks, not over the main repository. This is to ensure
+  that the main repository is not cluttered with lots of branches from contributors.
+ 
+### Tagging
+
 - Version tags are used for each release of the document
 - Releases should be versioned and if needed, appended with a pre-release tag,
   e.g. "v1", "v3-RC1", "v4-IIW39"
 - Versioning should be simple, only major releases numbered, prepended with
   letter v. e.g. v1, v2, v3.
-- Please
-  [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
-  the repository to make changes and submit a PR to request them for review.
 - Branch protection rules will exist to not allow a person to directly commit to
   `main`.
 
-### Issues
+### Pull Requests
+
+The below documents some basic best practices for your pull requests.
+
+- Please make sure to ask an editor to review your Pull Request. 
+- Write descriptive and consistent names.
+- Create a clear PR title and description.
+- Keep PRs short as possible 
+- Try to keep a transparent audit trail of your conversation so people can
+  follow it.
+- Avoid rewrites by getting feedback early.
+- Request additional reviewers to create dialogue.
+- Be precise in your comments about what needs to be fixed.
+
+### Review
+
+- Review of PR's is done by appointed editors. See the
+  [GOVERNANCE](GOVERNANCE.md) file for more information.
+- Issues labeled with `status: needs-review` should contain a PR code OR the
+  change text directly in the issue (for those not Git-savvy)
+- When you create an issue or a PR, please try to tag them appropriately,
+  including adding a `status: needs-review` label to the issue/PR.
+- Every week, the editors will go through the issues and tag them appropriately.
+- If the PR is ready to be merged, it is tagged with `accepted` -label
+- In normal circumstances, any editor may merge changes tagged with label
+  `accepted`
+- The editor can try to merge the PR to the main branch.
+- If PR is not rebased and commit histories are not in sync, the PR can be
+  merged if there are no overlapping changes with the history. In this case it
+  is the merging editor's responsibility to ensure that the merging is clean and
+  no unwanted changes happen.
+- In case of change conflicts, the editor requests the PR creator to rebase
+  against current main branch and resubmit the PR.
+- After review, an `editor` may change the status to `status: last-call`. This
+  would signal a 5 day delay for close.
+- If nobody disagrees with the `status: last-call`, the issue is accepted and
+  merged back into `main`.
+- Sometimes the editor group may agree to a controlled merging process and
+  decide that merging happens only by a selected editor (e.g. release owner) or
+  during editor meetings. This may happen when a release of the document is
+  coming soon and only some specific changes are allowed.
+
+## Issues
 
 - Anyone may raise an issue
 - Every week editors will go through the new issues, and label them.
@@ -58,6 +155,8 @@ are always answering the following:
    * what would trigger closure of the ticket?
 - Issues that are not commented on for over 90 days, and reviewed to not be
   relevant will be closed by an editor
+- Please do not hesitate to self assign yourself if you would like to address an
+  issue. 
 
 ## Labels
 
@@ -107,76 +206,3 @@ issue, so that we may accurately classify the work to do on it.
 | status | PR-accepted | The issue is linked to a PR that has been accepted and is waiting for merge. |
 | status | PR-merged | The issue is linked to a PR that has been merged; this issue can now be closed. |
 | status | status: last-call | The issue has been resolved by some other mechanism documented in the comments and is now in **5 day last call.** |
-
-## Changes to document
-
-- Change proposals can be made by anyone by creating an issue in Git and
-  proposing a pull request against the main branch, containing the proposed
-  changes.
-- Change proposals are made as according to the process below
-- Editors may make changes to the main branch without creating an issue, in the
-  case where an issue has not been already created. If an issue already exists
-  for the change, the editor should follow the standard review process and refer
-  the PR in the issue
-
-### Making a Pull Request 
-
-#### Basic Flow
-
-If you're not familiar with Github and Git, here's a few simple steps you can
-use to get going and to contribute to the repository *without ever touching the
-command line*.
-
-1. [Fork the TechArch repo into your
-   account](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
-2. Find the file you want to edit. [Click the pen tool on the top right of
-   the file to edit it.](https://www.youtube.com/watch?v=uE2DxUfZjtE) If you
-   want to add a file, click "Add File". Generally, when you save it is better
-   to click "create new branch".
-3. Make your changes. When you are ready, click [Pull
-   Request](https://youtu.be/rgbCcBNZcdQ?t=205)
-   on the bar above the file. Then create `New Pull Request` and choose to set
-   the request to merge to the `TechArch:main` branch. Put any information you
-   want to describe your changes on the description, and you're done!
-   
-#### Advanced Flow
-
-As a more advanced user, there are few ways you can manage your Github
-repository:
-
-1. [You can use the github web
-   editor](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor)
-2. [You can use github desktop](https://desktop.github.com/)
-3. [You can use the
-   cli](https://git-scm.com/book/en/v2/Getting-Started-The-Command-Line)
-4. Something else!
-
-This document will document the basic flow.
-
-### Review and Merge Process
-
-- Review of PR's is done by appointed editors. See the
-  [GOVERNANCE](GOVERNANCE.md) file for more information.
-- Issues labeled with `status: needs-review` should contain a PR code OR the
-  change text directly in the issue (for those not Git-savvy)
-- When you create an issue or a PR, please try to tag them appropriately,
-  including adding a `status: needs-review` label to the issue/PR.
-- Every week, the editors will go through the issues and tag them appropriately.
-- If the PR is ready to be merged, it is tagged with `accepted` -label
-- In normal circumstances, any editor may merge changes tagged with label
-  `accepted`
-- The editor can try to merge the PR to the main branch.
-- If PR is not rebased and commit histories are not in sync, the PR can be
-  merged if there are no overlapping changes with the history. In this case it
-  is the merging editor's responsibility to ensure that the merging is clean and
-  no unwanted changes happen.
-- In case of change conflicts, the editor requests the PR creator to rebase
-  against current main branch and resubmit the PR.
-- After review, an `editor` may change the status to `status: last-call`. This
-  would signal a 5 day delay for close.
-- If nobody disagrees with the `status: last-call`, the issue is accepted and
-  merged back into `main`.
-- Sometimes the editor group may agree to a controlled merging process and
-  decide that merging happens only by a selected editor (e.g. release owner) or
-  during editor meetings. This may happen when a release of the document is
-  coming soon and only some specific changes are allowed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,161 @@
+# Contribution Guide
+
+There are many ways to be a contributor, and we're here to help you on your way! You may:
+
+* Propose ideas in our discussion forums
+* Raise an [issue](https://github.com/trustoverip/TechArch/issues) or feature request in our issue tracker
+* Help another contributor with one of their questions, or a documentation review
+* Suggest improvements by supplying a [Pull
+  Request](https://github.com/trustoverip/TechArch/pulls) or opening a
+  [Discussion](https://github.com/trustoverip/TechArch/discussions)
+* Evangelize our work together in conferences, podcasts, and social media spaces.
+
+This guide is for you.
+
+## Table Of Contents
+
+* [Setup](#setup)
+* [Branching And Tagging](#branching-and-tagging)
+* [Issues](#issues)
+* [Labels](#labels)
+  * [Priority Labels](#priority-labels)
+  * [Type Labels](#type-labels)
+  * [Status Labels](#status-labels)
+* [Changes to Document](#changes-to-document)
+* [Editing Git Process](#editing-git-process)
+* [Review and Merge Process](#review-and-merge-process)
+
+## Contribution
+
+### Setup
+
+First, the Working Group or Task Force ("group") should contact the ToIP
+Foundation Program Manager (currently Elisa Trevino) to request setup of a
+GitHub repo for the deliverable. The group should also request that Github
+Discussions be turned on for the repo so the Discussions feature is available to
+the group for Q&A or other discussions that are not necessarily issues (but can
+be quickly converted into a formal issue when needed).
+
+
+### Branching and Tagging:
+
+- The main-branch should always have the latest approved changes
+- Custom "feature" branches may be used for special purposes, e.g. for groups to
+  work on a larger section of text
+- Version tags are used for each release of the document
+- Releases should be versioned and if needed, appended with a pre-release tag,
+  e.g. "v1", "v3-RC1", "v4-IIW39"
+- Versioning should be simple, only major releases numbered, prepended with
+  letter v. e.g. v1, v2, v3.
+- Please
+  [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
+  the repository to make changes and submit a PR to request them for review.
+- Branch protection rules will exist to not allow a person to directly commit to
+  `main`.
+
+### Issues
+
+- Anyone may raise an issue
+- Every week editors will go through the new issues, and label them.
+- Please provide as much clarity as possible around an issue topic. Ideally, you
+are always answering the following:
+   * what is the issue?
+   * why is it important?
+   * what would trigger closure of the ticket?
+- Issues that are not commented on for over 90 days, and reviewed to not be
+  relevant will be closed by an editor
+
+## Labels
+
+### Priority Labels
+
+Priority labels are used to describe the impact and focus of the issue. Higher
+priority means it is more likely to find focus within the group.
+
+| Priority | Label    | Usage                                                                                      |
+|----------|----------|--------------------------------------------------------------------------------------------|
+| priority | critical | Progress on this issue is critical to the group's forward progress.                        |
+| priority | high     | It is important for the group to resolve this issue soon.                                  |
+| priority | medium   | This issue is important to resolve before the next release.                                |
+| priority | low      | This issue is "nice to have" for the next release, but could be deferred if time runs out. |
+
+### Type Labels 
+
+Type labels are labels the define the nature of the issue and/or the correction itself.
+
+| Type | Label      | Usage                                                                      |
+|------|------------|----------------------------------------------------------------------------|
+| type | editorial  | The issue only involves wording and not normative content.                 |
+| type | content    | The issue involves normative content; resolution requires group consensus. |
+| type | correction | The issue is fixing a recognized problem in the current version.           |
+| type | formatting | The issue involves fixing formatting.                                      |
+| type | figure     | The issue involves a figure that it missing or needs to be revised.        |
+| type | admin      | The issue is administrative and NOT about the deliverable.                 |
+
+### Status Labels 
+
+Status labels are labels that are used to help identify the current state of
+the issue, so that we may accurately classify the work to do on it.
+
+| Status | Label             | Usage                                                                                                             |
+|--------|-------------------|-------------------------------------------------------------------------------------------------------------------|
+| status | unassigned        | The issue is new and has not yet been assigned to anyone.                                                         |
+| status | in-progress       | The issue has been assigned and work is in progress.                                                              |
+| status | needs-review      | A resolution (or concrete step forward) has been proposed and needs review.                                       |
+| status | blocked           | Progress is currently blocked; the block should be explained in a comment.                                        |
+| status | on-hold           | Progress is currently on hold; the reason should be explained in a comment.                                       |
+| status | deferred          | Consensus has been reached that this issue can be deferred to a subsequent version.                               |
+| status | abandoned         | Consensus has been reached that this issue can be abandoned.                                                      |
+| status | PR-needed         | Consensus has been reached and this issue is now waiting for a PR to be submitted.                                |
+| status | PR-in-progress    | The issue is linked to a PR that is in progress                                                                   |
+| status | PR-completed      | The issue is linked to a PR that is complete and waiting for review.                                              |
+| status | PR-accepted       | The issue is linked to a PR that has been accepted and is waiting for merge.                                      |
+| status | PR-merged         | The issue is linked to a PR that has been merged; this issue can now be closed.                                   |
+| status | status: last-call | The issue has been resolved by some other mechanism documented in the comments and is now in **5 day last call.** |
+
+## Changes to document
+
+- Change proposals can be made by anyone by creating an issue in Git and proposing a pull request against the main branch, containing the proposed changes.
+- Change proposals are made as according to the process below
+- Editors may make changes to the main branch without creating an issue, in the case where an issue has not been already created. If an issue already exists for the change, the editor should follow the standard review process and refer the PR in the issue
+
+### Editing Git process
+1) Create a [clone](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository) of the repo or [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
+ the repo
+2) Make changes to the document on your own repo
+3) Ensure commit history sync by rebasing own repo with 'git pull rebase'
+4) Create a pull request against the ToIP repo main branch
+5) Refer to the PR in the relevant issue(s).
+6) Contributor sets the issue to label "Needs review" to signal editors to review the changes
+
+You may also put your PR in
+[draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to
+signal a wip that can be collaborated on with other people.
+
+### Review and Merge Process
+
+- Review of PR's is done by appointed editors. See the
+  [GOVERNANCE](GOVERNANCE.md) file for more information.
+- Issues labeled with `status: needs-review` should contain a PR code OR the
+  change text directly in the issue (for those not Git-savvy)
+- When you create an issue or a PR, please try to tag them appropriately,
+  including adding a `status: needs-review` label to the issue/PR.
+- Every week, the editors will go through the issues and tag them appropriately.
+- If the PR is ready to be merged, it is tagged with `accepted` -label
+- In normal circumstances, any editor may merge changes tagged with label
+  `accepted`
+- The editor can try to merge the PR to the main branch.
+- If PR is not rebased and commit histories are not in sync, the PR can be
+  merged if there are no overlapping changes with the history. In this case it
+  is the merging editor's responsibility to ensure that the merging is clean and
+  no unwanted changes happen.
+- In case of change conflicts, the editor requests the PR creator to rebase
+  against current main branch and resubmit the PR.
+- After review, an `editor` may change the status to `status: last-call`. This would
+  signal a 5 day delay for close. 
+- If nobody disagrees with the `status: last-call`, the issue is accepted and
+  merged back into `main`.
+- Sometimes the editor group may agree to a controlled merging process and
+  decide that merging happens only by a selected editor (e.g. release owner) or
+  during editor meetings. This may happen when a release of the document is
+  coming soon and only some specific changes are allowed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,25 +119,39 @@ issue, so that we may accurately classify the work to do on it.
   for the change, the editor should follow the standard review process and refer
   the PR in the issue
 
-### Editing Git process
-1. Create a
- [clone](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository) of
- the repo or
- [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
- the repo 
- 2. Make changes to the document on your own repo 
- 3. Ensure commit
- history sync by rebasing own repo with 'git pull rebase' 
- 4. Create a pull
- request against the ToIP repo main branch 
- 5. Refer to the PR in the relevant
- issue(s). 
- 6. Contributor sets the issue to label "Needs review" to signal
- editors to review the changes
+### Making a Pull Request 
 
-You may also put your PR in
-[draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to
-signal a wip that can be collaborated on with other people.
+#### Basic Flow
+
+If you're not familiar with Github and Git, here's a few simple steps you can
+use to get going and to contribute to the repository *without ever touching the
+command line*.
+
+1. [Fork the TechArch repo into your
+   account](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
+2. Find the file you want to edit. [Click the pen tool on the top right of
+   the file to edit it.](https://www.youtube.com/watch?v=uE2DxUfZjtE) If you
+   want to add a file, click "Add File". Generally, when you save it is better
+   to click "create new branch".
+3. Make your changes. When you are ready, click [Pull
+   Request](https://youtu.be/rgbCcBNZcdQ?t=205)
+   on the bar above the file. Then create `New Pull Request` and choose to set
+   the request to merge to the `TechArch:main` branch. Put any information you
+   want to describe your changes on the description, and you're done!
+   
+#### Advanced Flow
+
+As a more advanced user, there are few ways you can manage your Github
+repository:
+
+1. [You can use the github web
+   editor](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor)
+2. [You can use github desktop](https://desktop.github.com/)
+3. [You can use the
+   cli](https://git-scm.com/book/en/v2/Getting-Started-The-Command-Line)
+4. Something else!
+
+This document will document the basic flow.
 
 ### Review and Merge Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,18 @@
 # Contribution Guide
 
-There are many ways to be a contributor, and we're here to help you on your way! You may:
+There are many ways to be a contributor, and we're here to help you on your way!
+You may:
 
 * Propose ideas in our discussion forums
-* Raise an [issue](https://github.com/trustoverip/TechArch/issues) or feature request in our issue tracker
-* Help another contributor with one of their questions, or a documentation review
+* Raise an [issue](https://github.com/trustoverip/TechArch/issues) or feature
+  request in our issue tracker
+* Help another contributor with one of their questions, or a documentation
+  review
 * Suggest improvements by supplying a [Pull
   Request](https://github.com/trustoverip/TechArch/pulls) or opening a
   [Discussion](https://github.com/trustoverip/TechArch/discussions)
-* Evangelize our work together in conferences, podcasts, and social media spaces.
+* Evangelize our work together in conferences, podcasts, and social media
+  spaces.
 
 This guide is for you.
 
@@ -72,61 +76,69 @@ are always answering the following:
 Priority labels are used to describe the impact and focus of the issue. Higher
 priority means it is more likely to find focus within the group.
 
-| Priority | Label    | Usage                                                                                      |
+| Priority | Label | Usage |
 |----------|----------|--------------------------------------------------------------------------------------------|
-| priority | critical | Progress on this issue is critical to the group's forward progress.                        |
-| priority | high     | It is important for the group to resolve this issue soon.                                  |
-| priority | medium   | This issue is important to resolve before the next release.                                |
-| priority | low      | This issue is "nice to have" for the next release, but could be deferred if time runs out. |
+| priority | critical | Progress on this issue is critical to the group's forward progress. |
+| priority | high | It is important for the group to resolve this issue soon. |
+| priority | medium | This issue is important to resolve before the next release. |
+| priority | low | This issue is "nice to have" for the next release, but could be deferred if time runs out. |
 
 ### Type Labels 
 
-Type labels are labels the define the nature of the issue and/or the correction itself.
+Type labels are labels the define the nature of the issue and/or the correction
+itself.
 
-| Type | Label      | Usage                                                                      |
+| Type | Label | Usage |
 |------|------------|----------------------------------------------------------------------------|
-| type | editorial  | The issue only involves wording and not normative content.                 |
-| type | content    | The issue involves normative content; resolution requires group consensus. |
-| type | correction | The issue is fixing a recognized problem in the current version.           |
-| type | formatting | The issue involves fixing formatting.                                      |
-| type | figure     | The issue involves a figure that it missing or needs to be revised.        |
-| type | admin      | The issue is administrative and NOT about the deliverable.                 |
+| type | editorial | The issue only involves wording and not normative content. |
+| type | content | The issue involves normative content; resolution requires group consensus. |
+| type | correction | The issue is fixing a recognized problem in the current version. |
+| type | formatting | The issue involves fixing formatting. |
+| type | figure | The issue involves a figure that it missing or needs to be revised. |
+| type | admin | The issue is administrative and NOT about the deliverable. |
 
 ### Status Labels 
 
-Status labels are labels that are used to help identify the current state of
-the issue, so that we may accurately classify the work to do on it.
+Status labels are labels that are used to help identify the current state of the
+issue, so that we may accurately classify the work to do on it.
 
-| Status | Label             | Usage                                                                                                             |
+| Status | Label | Usage |
 |--------|-------------------|-------------------------------------------------------------------------------------------------------------------|
-| status | unassigned        | The issue is new and has not yet been assigned to anyone.                                                         |
-| status | in-progress       | The issue has been assigned and work is in progress.                                                              |
-| status | needs-review      | A resolution (or concrete step forward) has been proposed and needs review.                                       |
-| status | blocked           | Progress is currently blocked; the block should be explained in a comment.                                        |
-| status | on-hold           | Progress is currently on hold; the reason should be explained in a comment.                                       |
-| status | deferred          | Consensus has been reached that this issue can be deferred to a subsequent version.                               |
-| status | abandoned         | Consensus has been reached that this issue can be abandoned.                                                      |
-| status | PR-needed         | Consensus has been reached and this issue is now waiting for a PR to be submitted.                                |
-| status | PR-in-progress    | The issue is linked to a PR that is in progress                                                                   |
-| status | PR-completed      | The issue is linked to a PR that is complete and waiting for review.                                              |
-| status | PR-accepted       | The issue is linked to a PR that has been accepted and is waiting for merge.                                      |
-| status | PR-merged         | The issue is linked to a PR that has been merged; this issue can now be closed.                                   |
+| status | unassigned | The issue is new and has not yet been assigned to anyone. |
+| status | in-progress | The issue has been assigned and work is in progress. |
+| status | needs-review | A resolution (or concrete step forward) has been proposed and needs review. |
+| status | blocked | Progress is currently blocked; the block should be explained in a comment. |
+| status | on-hold | Progress is currently on hold; the reason should be explained in a comment. |
+| status | deferred | Consensus has been reached that this issue can be deferred to a subsequent version. |
+| status | abandoned | Consensus has been reached that this issue can be abandoned. |
+| status | PR-needed | Consensus has been reached and this issue is now waiting for a PR to be submitted. |
+| status | PR-in-progress | The issue is linked to a PR that is in progress |
+| status | PR-completed | The issue is linked to a PR that is complete and waiting for review. |
+| status | PR-accepted | The issue is linked to a PR that has been accepted and is waiting for merge. |
+| status | PR-merged | The issue is linked to a PR that has been merged; this issue can now be closed. |
 | status | status: last-call | The issue has been resolved by some other mechanism documented in the comments and is now in **5 day last call.** |
 
 ## Changes to document
 
-- Change proposals can be made by anyone by creating an issue in Git and proposing a pull request against the main branch, containing the proposed changes.
+- Change proposals can be made by anyone by creating an issue in Git and
+  proposing a pull request against the main branch, containing the proposed
+  changes.
 - Change proposals are made as according to the process below
-- Editors may make changes to the main branch without creating an issue, in the case where an issue has not been already created. If an issue already exists for the change, the editor should follow the standard review process and refer the PR in the issue
+- Editors may make changes to the main branch without creating an issue, in the
+  case where an issue has not been already created. If an issue already exists
+  for the change, the editor should follow the standard review process and refer
+  the PR in the issue
 
 ### Editing Git process
-1) Create a [clone](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository) of the repo or [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
- the repo
-2) Make changes to the document on your own repo
-3) Ensure commit history sync by rebasing own repo with 'git pull rebase'
-4) Create a pull request against the ToIP repo main branch
-5) Refer to the PR in the relevant issue(s).
-6) Contributor sets the issue to label "Needs review" to signal editors to review the changes
+1) Create a
+ [clone](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository) of
+ the repo or
+ [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks)
+ the repo 2) Make changes to the document on your own repo 3) Ensure commit
+ history sync by rebasing own repo with 'git pull rebase' 4) Create a pull
+ request against the ToIP repo main branch 5) Refer to the PR in the relevant
+ issue(s). 6) Contributor sets the issue to label "Needs review" to signal
+ editors to review the changes
 
 You may also put your PR in
 [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to
@@ -151,8 +163,8 @@ signal a wip that can be collaborated on with other people.
   no unwanted changes happen.
 - In case of change conflicts, the editor requests the PR creator to rebase
   against current main branch and resubmit the PR.
-- After review, an `editor` may change the status to `status: last-call`. This would
-  signal a 5 day delay for close. 
+- After review, an `editor` may change the status to `status: last-call`. This
+  would signal a 5 day delay for close.
 - If nobody disagrees with the `status: last-call`, the issue is accepted and
   merged back into `main`.
 - Sometimes the editor group may agree to a controlled merging process and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 There are many ways to be a contributor, and we're here to help you on your way!
 You may:
 
-* Propose ideas in our discussion forums
+* Join the discussion and share ideas in our [Slack channel](trustoverip.slack.com) and regular [TSWG](https://wiki.trustoverip.org/display/HOME/Technology+Stack+Working+Group?src=contextnavpagetreemode) and [TATF](https://wiki.trustoverip.org/display/HOME/Technology+Architecture+Task+Force) meetings.
 * Raise an [issue](https://github.com/trustoverip/TechArch/issues) or feature
   request in our issue tracker
 * Help another contributor with one of their questions, or a documentation
@@ -30,16 +30,6 @@ This guide is for you.
 * [Review and Merge Process](#review-and-merge-process)
 
 ## Contribution
-
-### Setup
-
-First, the Working Group or Task Force ("group") should contact the ToIP
-Foundation Program Manager (currently Elisa Trevino) to request setup of a
-GitHub repo for the deliverable. The group should also request that Github
-Discussions be turned on for the repo so the Discussions feature is available to
-the group for Q&A or other discussions that are not necessarily issues (but can
-be quickly converted into a formal issue when needed).
-
 
 ### Branching and Tagging:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,9 @@ If you're not familiar with Github and Git, here's a few simple steps you can
 use to get going and to contribute to the repository *without ever touching the
 command line*.
 
+There is also a [Video Walkthrough](https://www.youtube.com/embed/3CuB0wdJaSU) 
+of how to do this if you prefer to learn over video.
+
 1. [Fork the TechArch repo into your
    account](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
    
@@ -65,11 +68,12 @@ command line*.
    Request](https://youtu.be/rgbCcBNZcdQ?t=205) on the bar above the file. Then
    create `New Pull Request` and choose to set the request to merge to the
    `TechArch:main` branch. Put any information you want to describe your changes
-   on the description, and you're done! [Learn More](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
+   on the description, and you're done! [Learn More](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
    
    <div align="center"><img width=400 src=https://user-images.githubusercontent.com/8604639/196454843-23080862-1f8a-4514-a3e0-59bfb9350adf.png></div>
    <div align="center"><img width=400 src=https://user-images.githubusercontent.com/8604639/196454824-a20039f9-ab87-4806-b321-891eea222438.png></div>
-   
+
+  
 ### Advanced Change Flow
 
 As a more advanced user, there are few ways you can manage your Github

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -47,6 +47,13 @@ and proposing when an issue is ready for closure.
 * Prioritizing issues.
 * Finding the appropriate `assignee` to work on an issue.
 * Create issues that are required for advancement of the repository.
+* Helping users and novice contributors
+* Contributing code and documentation changes that improve the project
+* Reviewing and commenting on issues and pull requests
+* Participation in working groups
+* Merging pull requests
+* Ensuring clean commit history
+* Flagging breaches related to the code of conduct
 
 ### Policies
 
@@ -100,19 +107,17 @@ proposed resolution. This subgroup should:
     reach final consensus on closure.
 
 ## Maintainers
+
 Maintainers have write access to GitHub repositories and act as project administrators.
-They approve and merge pull requests, cut releases, and guide collaboration 
-with the community
+They approve release cuts, and guide collaboration with the community.
 
 ### Activities
 
-* Helping users and novice contributors
-* Contributing code and documentation changes that improve the project
-* Reviewing and commenting on issues and pull requests
-* Participation in working groups
-* Merging pull requests
-* Ability to merge PR's
-* Commit access to their project's repositories
+* All the editor activities
+* Configuration of the repository
+* Version and release cutting
+* Approving updates to CODEOWNERS 
+* Enforcing community conduct regulations via Github.
 
 ### Policies
 
@@ -124,9 +129,6 @@ and merge (land) pull requests.
   the deliverable. Typically a subset of the Editors serve as Maintainers, but
   all the Editors can serve in this role, or it can be assigned to others in the
   group.
-* If a maintainer opposes a proposed change, then the change cannot land. The
-  exception is if the Governance Committee ( GC) votes to approve the change
-  despite the opposition. Usually, involving the GC is unnecessary.
 
 ## Administrators
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,11 +7,15 @@
 
 ## Contributors
 
-Anyone may be a contributor to the Technology Architecture Project. Contribution
-may take the form of:
-
-Anyone with a GitHub account may use the project issue trackers and
-communications channels. We welcome newcomers, so don't hesitate to say hi
+For the protection of all Members, participation in working groups, meetings and
+events is limited to members, including their employees, of the Trust over IP
+Foundation who have signed the membership documents and thus agreed to the
+intellectual property rules governing participation. If you or your employer are
+not a member of ToIP, you may not participate in meetings by verbal contribution
+or otherwise take any action beyond observing. [To join
+ToIP](https://trustoverip.org/get-involved/membership/) and be able to
+contribute, please fill out the light weight membership application on our
+website [here](https://trustoverip.org/get-involved/membership/).
 
 ### Contributor Activities
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,4 +1,13 @@
-# Tech Arch Governance Framework
+# Tech Arch Repository Governance Framework
+
+This document scopes the roles within maintanence of the **TechArch repository** and 
+is not related to the roles of Trust over IP organization. The intent of this document
+is to enumerate the various responsibilities and rights of various active roles within 
+the repository. 
+
+## Roles
+
+The TechArch repository currently defines 4 roles:
 
 * [Contributors](#contributors)
 * [Maintainers](#maintainers)
@@ -17,7 +26,7 @@ ToIP](https://trustoverip.org/get-involved/membership/) and be able to
 contribute, please fill out the light weight membership application on our
 website [here](https://trustoverip.org/get-involved/membership/).
 
-### Contributor Activities
+### Activities
 
 * Asking and answering questions on the development forums
 * Filing an issue
@@ -29,9 +38,18 @@ website [here](https://trustoverip.org/get-involved/membership/).
 
 ## Editors
 
-* The Working Group or Task Force ("group") should appoint an Editors team who
-  will take on the job of reviewing issues, assigning group members to an issue,
-  and proposing when an issue is ready for closure.
+The Editors team who are responsible for reviewing issues, assigning group members to an issue,
+and proposing when an issue is ready for closure.
+
+### Activities
+
+* Labelling issues on weekly review.
+* Prioritizing issues.
+* Finding the appropriate `assignee` to work on an issue.
+* Create issues that are required for advancement of the repository.
+
+### Policies
+
 * As a general rule, any one member of the Editors team can perform an action
   permitted under this role — it does not require consensus among all the
   Editors. However the Editors are trusted to use their judgement about when
@@ -44,11 +62,12 @@ website [here](https://trustoverip.org/get-involved/membership/).
   are assigned consistently, fairly, and timely. If an assignee is not
   progressing with an issue, the Editors can re-assign it as necessary.
 
-### Subgroups
+#### Subgroups
 
 If an issue appears to require in-depth discussion and analysis, the Editors
 should assign a subgroup to tackle the issue and come back to the group with a
 proposed resolution. This subgroup should:
+
 * Keep as much of their discussion as possible within GitHub Issues — and, if
   necessary, Github Discussions. If any substantive discussions take place in
   other channels (e.g., Slack) or proposals are drafted outside of GitHub (e.g.,
@@ -63,7 +82,7 @@ proposed resolution. This subgroup should:
   can be easily: a) turned into a PR (for a GitHub document), or b)
   copy-and-pasted as a revision to a Google doc or other format.
 
-### Closure
+#### Closure
 
 * If the Editors believe an issue has been resolved via one or more PRs that
   have been accepted and merged, then one of the Editors should apply the label
@@ -80,20 +99,23 @@ proposed resolution. This subgroup should:
   * If there is an objection, the Editors will take it to a group meeting to
     reach final consensus on closure.
 
-### Editor Activities
-
-* Labelling issues on weekly review.
-* Prioritizing issues.
-* Finding the appropriate `assignee` to work on an issue.
-* Create issues that are required for advancement of the repository.
-
 ## Maintainers
+Maintainers have write access to GitHub repositories and act as project administrators.
+They approve and merge pull requests, cut releases, and guide collaboration 
+with the community
 
-* Maintainers have write access to GitHub repositories and act as project
-  administrators. They approve and merge pull requests, cut releases, and guide
-  collaboration with the community. They have:
-  * Ability to merge PR's
-  * Commit access to their project's repositories
+### Activities
+
+* Helping users and novice contributors
+* Contributing code and documentation changes that improve the project
+* Reviewing and commenting on issues and pull requests
+* Participation in working groups
+* Merging pull requests
+* Ability to merge PR's
+* Commit access to their project's repositories
+
+### Policies
+
 * Both maintainers and non-maintainers may propose changes to source code. The
 mechanism to propose such a change is a GitHub pull request. Maintainers review
 and merge (land) pull requests.
@@ -106,20 +128,12 @@ and merge (land) pull requests.
   exception is if the Governance Committee ( GC) votes to approve the change
   despite the opposition. Usually, involving the GC is unnecessary.
 
-### Maintainer activities
-
-* Helping users and novice contributors
-* Contributing code and documentation changes that improve the project
-* Reviewing and commenting on issues and pull requests
-* Participation in working groups
-* Merging pull requests
-
 ## Administrators
 
-* Administrators are responsible for setting repository settings and allocating
-  new access controls for community. 
+Administrators are responsible for setting repository settings and allocating
+new access controls for community. 
   
-### Administrator Activities
+### Activities
 
 * Setting a Github feature in the repo.
 * Adding a person as a maintainer.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -42,18 +42,39 @@ communications channels. We welcome newcomers, so don't hesitate to say hi
 
 ### Subgroups
 
-If an issue appears to require in-depth discussion and analysis, the Editors should assign a subgroup to tackle the issue and come back to the group with a proposed resolution. This subgroup should:
-* Keep as much of their discussion as possible within GitHub Issues — and, if necessary, Github Discussions. If any substantive discussions take place in other channels (e.g., Slack) or proposals are drafted outside of GitHub (e.g., in a Google doc), they must be copied into GitHub to create a permanent public audit trail.
-* Hold special calls/meetings if needed, but record those meetings and document key discussion points and decisions and copy those to GitHub.
-* Develop a proposed resolution to the issue (along the lines of an ISO "Technical Report").
-* Return with a proposal (text and diagrams) for resolution of the issue (along the lines of an ISO "Technical Spec"). Ideally this proposal is in a form that can be easily: a) turned into a PR (for a GitHub document), or b) copy-and-pasted as a revision to a Google doc or other format.
+If an issue appears to require in-depth discussion and analysis, the Editors
+should assign a subgroup to tackle the issue and come back to the group with a
+proposed resolution. This subgroup should:
+* Keep as much of their discussion as possible within GitHub Issues — and, if
+  necessary, Github Discussions. If any substantive discussions take place in
+  other channels (e.g., Slack) or proposals are drafted outside of GitHub (e.g.,
+  in a Google doc), they must be copied into GitHub to create a permanent public
+  audit trail.
+* Hold special calls/meetings if needed, but record those meetings and document
+  key discussion points and decisions and copy those to GitHub.
+* Develop a proposed resolution to the issue (along the lines of an ISO
+  "Technical Report").
+* Return with a proposal (text and diagrams) for resolution of the issue (along
+  the lines of an ISO "Technical Spec"). Ideally this proposal is in a form that
+  can be easily: a) turned into a PR (for a GitHub document), or b)
+  copy-and-pasted as a revision to a Google doc or other format.
 
 ### Closure
 
-* If the Editors believe an issue has been resolved via one or more PRs that have been accepted and merged, then one of the Editors should apply the label status: PR-merged and close the issue. If the Editors believe consensus has been achieved about some other resolution of the issue — and that resolution is fully documented in the issue — then one of the Editors should apply the label `status: last-call`.
-  * Once that label has been applied, a group member MUST object to closure by making a comment on the issue within 5 calendar days to reopen discussion of the issue.
-  * If there is no objection within 5 calendar days, the proposed resolution shall be applied to the deliverable by one of the Maintainers and one of the Editors shall close the issue with no further discussion.
-  * If there is an objection, the Editors will take it to a group meeting to reach final consensus on closure.
+* If the Editors believe an issue has been resolved via one or more PRs that
+  have been accepted and merged, then one of the Editors should apply the label
+  status: PR-merged and close the issue. If the Editors believe consensus has
+  been achieved about some other resolution of the issue — and that resolution
+  is fully documented in the issue — then one of the Editors should apply the
+  label `status: last-call`.
+  * Once that label has been applied, a group member MUST object to closure by
+    making a comment on the issue within 5 calendar days to reopen discussion of
+    the issue.
+  * If there is no objection within 5 calendar days, the proposed resolution
+    shall be applied to the deliverable by one of the Maintainers and one of the
+    Editors shall close the issue with no further discussion.
+  * If there is an objection, the Editors will take it to a group meeting to
+    reach final consensus on closure.
 
 ### Editor Activities
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,105 @@
+# Tech Arch Governance Framework
+
+* [Contributors](#contributors)
+* [Maintainers](#maintainers)
+* [Editors](#editors)
+* [Administrators](#administrators)
+
+## Contributors
+
+Anyone may be a contributor to the Technology Architecture Project. Contribution
+may take the form of:
+
+Anyone with a GitHub account may use the project issue trackers and
+communications channels. We welcome newcomers, so don't hesitate to say hi
+
+### Contributor Activities
+
+* Asking and answering questions on the development forums
+* Filing an issue
+* Offering a feature or bug fix via a Pull Request
+* Suggesting documentation improvements
+* Improving documentation
+* Self assign issues
+* If appropriate, assign another group member
+
+## Editors
+
+* The Working Group or Task Force ("group") should appoint an Editors team who
+  will take on the job of reviewing issues, assigning group members to an issue,
+  and proposing when an issue is ready for closure.
+* As a general rule, any one member of the Editors team can perform an action
+  permitted under this role — it does not require consensus among all the
+  Editors. However the Editors are trusted to use their judgement about when
+  they should consult the other editors first or seek the consensus of the whole
+  group.
+* The members of the Editor team should be published on the group's home page
+  and acknowledged in the final deliverable for their extra contribution
+* Any group member should be able to assign an issue to another group member. It
+  is the Editors job to try to make sure issues have assignees, and that issues
+  are assigned consistently, fairly, and timely. If an assignee is not
+  progressing with an issue, the Editors can re-assign it as necessary.
+
+### Subgroups
+
+If an issue appears to require in-depth discussion and analysis, the Editors should assign a subgroup to tackle the issue and come back to the group with a proposed resolution. This subgroup should:
+* Keep as much of their discussion as possible within GitHub Issues — and, if necessary, Github Discussions. If any substantive discussions take place in other channels (e.g., Slack) or proposals are drafted outside of GitHub (e.g., in a Google doc), they must be copied into GitHub to create a permanent public audit trail.
+* Hold special calls/meetings if needed, but record those meetings and document key discussion points and decisions and copy those to GitHub.
+* Develop a proposed resolution to the issue (along the lines of an ISO "Technical Report").
+* Return with a proposal (text and diagrams) for resolution of the issue (along the lines of an ISO "Technical Spec"). Ideally this proposal is in a form that can be easily: a) turned into a PR (for a GitHub document), or b) copy-and-pasted as a revision to a Google doc or other format.
+
+### Closure
+
+* If the Editors believe an issue has been resolved via one or more PRs that have been accepted and merged, then one of the Editors should apply the label status: PR-merged and close the issue. If the Editors believe consensus has been achieved about some other resolution of the issue — and that resolution is fully documented in the issue — then one of the Editors should apply the label `status: last-call`.
+  * Once that label has been applied, a group member MUST object to closure by making a comment on the issue within 5 calendar days to reopen discussion of the issue.
+  * If there is no objection within 5 calendar days, the proposed resolution shall be applied to the deliverable by one of the Maintainers and one of the Editors shall close the issue with no further discussion.
+  * If there is an objection, the Editors will take it to a group meeting to reach final consensus on closure.
+
+### Editor Activities
+
+* Labelling issues on weekly review.
+* Prioritizing issues.
+* Finding the appropriate `assignee` to work on an issue.
+* Create issues that are required for advancement of the repository.
+
+## Maintainers
+
+* Maintainers have write access to GitHub repositories and act as project
+  administrators. They approve and merge pull requests, cut releases, and guide
+  collaboration with the community. They have:
+  * Ability to merge PR's
+  * Commit access to their project's repositories
+* Both maintainers and non-maintainers may propose changes to source code. The
+mechanism to propose such a change is a GitHub pull request. Maintainers review
+and merge (land) pull requests.
+* The Editors should in turn appoint a set of Maintainers who have the Github
+  skills (and the necessary permissions) to accept PRs and publish versions of
+  the deliverable. Typically a subset of the Editors serve as Maintainers, but
+  all the Editors can serve in this role, or it can be assigned to others in the
+  group.
+* If a maintainer opposes a proposed change, then the change cannot land. The
+  exception is if the Governance Committee ( GC) votes to approve the change
+  despite the opposition. Usually, involving the GC is unnecessary.
+
+### Maintainer activities
+
+* Helping users and novice contributors
+* Contributing code and documentation changes that improve the project
+* Reviewing and commenting on issues and pull requests
+* Participation in working groups
+* Merging pull requests
+
+## Administrators
+
+* Administrators are responsible for setting repository settings and allocating
+  new access controls for community. 
+  
+### Administrator Activities
+
+* Setting a Github feature in the repo.
+* Adding a person as a maintainer.
+* Renaming the repository.
+* Blocking individuals from using the respository.
+* Setting security policies on the branches and repository.
+* Setting any keys to the repsository.
+* Integrating any new services, such as CICD to the repository.


### PR DESCRIPTION
Initial governance files of CODEOWNERS, CONTRIBUTING.md, and GOVERNANCE.md. Related to issues: 

https://github.com/trustoverip/TechArch/issues/40
https://github.com/trustoverip/TechArch/issues/39
https://github.com/trustoverip/TechArch/issues/38
https://github.com/trustoverip/TechArch/issues/46

These files are important for designating the repository management of the repo. A couple things: 

1. I will copy things to the wiki after, that being said, the source of truth is the repo, NOT the wiki. If things ever get out of alignment, the repo should be the single source of truth. 
2. I highlighted a few areas which are interesting/need some review. 