### PR TITLE
Update section 6.1 wrt "authenticity"

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -115,7 +115,7 @@ These twin objectives led the ToIP Foundation to begin the work with the Design 
 
 With regard to the first design goal, establishing trust between parties requires that each party develop confidence in the following properties of their relationship:
 
-1. **Authenticity:** is the receiver of a communication able to verify that it originated from the expected sender and has not been tampered with?[^1]
+1. **Authenticity:** is the receiver of a communication able to verify that it originated from the sender and has not been tampered with?[^1]
 2. **Confidentiality:** is the contents of a communication protected so only authorized parties have access?
 3. **Privacy:** will the expectations of each party with respect to usage of shared information be honored by the other parties?
 

--- a/spec.md
+++ b/spec.md
@@ -122,7 +122,7 @@ With regard to the first design goal, establishing trust between parties require
 Note that, in some trust relationships, confidentiality and privacy may be optional. Thus our design goal with the ToIP stack is to achieve these three properties in the order listed.[^2]
 
 [^1]: With respect to this design goal, authenticity includes **message integrity**, i.e., a communication is not authentic if it has been tampered with in any way.
-[^2]: Another standard information trust criteria is **availability**. This is a concern with the design and implementation of operational deployments of the ToIP stack and should be addressed in the associated operational governance frameworks.
+[^2]: Another important property of the architecture is **availability**. This is a concern with the design and implementation of operational deployments of the ToIP stack and should be addressed in the associated operational governance frameworks.
 
 With regard to the second design goal, the ToIP reference architecture shares the same goal of global scalability as the original Internet architecture. This involves several intertwined considerations that overlap and reinforce each other as summarized by the first four [Design Principles for the ToIP Stack](https://www.trustoverip.org/wp-content/uploads/Design-Principles-for-the-ToIP-Stack-V1.0-2022-01-17.pdf):
 

--- a/spec.md
+++ b/spec.md
@@ -115,14 +115,14 @@ These twin objectives led the ToIP Foundation to begin the work with the Design 
 
 With regard to the first design goal, establishing trust between parties requires that each party develop confidence in the following properties of their relationship:
 
-1. **Authenticity:** is the receiver of a communication able to verify that it originated from the expected sender?
-2. **Integrity:** is the receiver able to verify that a communication is complete and has not been tampered with?
-3. **Confidentiality:** is the contents of a communication protected so only authorized parties have access?
-4. **Privacy:** will the expectations of each party with respect to usage of shared information be honored by the other parties?
+1. **Authenticity:** is the receiver of a communication able to verify that it originated from the expected sender and has not been tampered with?[^1]
+2. **Confidentiality:** is the contents of a communication protected so only authorized parties have access?
+3. **Privacy:** will the expectations of each party with respect to usage of shared information be honored by the other parties?
 
-Note that, in some trust relationships, confidentiality and privacy may be optional. Thus our design goal with the ToIP stack is to achieve these four properties in the order listed.[^1]
+Note that, in some trust relationships, confidentiality and privacy may be optional. Thus our design goal with the ToIP stack is to achieve these three properties in the order listed.[^2]
 
-[^1]: Another standard information trust criteria is **availability**. This is a concern with the design and implementation of operational deployments of the ToIP stack and should be addressed in the associated operational governance frameworks.
+[^1]: With respect to this design goal, authenticity includes **message integrity**, i.e., a communication is not authentic if it has been tampered with in any way.
+[^2]: Another standard information trust criteria is **availability**. This is a concern with the design and implementation of operational deployments of the ToIP stack and should be addressed in the associated operational governance frameworks.
 
 With regard to the second design goal, the ToIP reference architecture shares the same goal of global scalability as the original Internet architecture. This involves several intertwined considerations that overlap and reinforce each other as summarized by the first four [Design Principles for the ToIP Stack](https://www.trustoverip.org/wp-content/uploads/Design-Principles-for-the-ToIP-Stack-V1.0-2022-01-17.pdf):
 


### PR DESCRIPTION
Revised the sentence describing "authenticity" and moved the explanation of "message integrity" to a footnote.